### PR TITLE
Fix serialization of undefined values

### DIFF
--- a/Erlang.js
+++ b/Erlang.js
@@ -891,6 +891,8 @@ Erlang._term_to_binary = function _term_to_binary (term) {
                     }
                     throw new OutputException('unknown javascript object type');
             }
+        case 'undefined':
+            return (new Erlang.OtpErlangAtom('nil')).binary();
         default:
             throw new OutputException('unknown javascript type');
     }

--- a/Erlang.js
+++ b/Erlang.js
@@ -30,6 +30,8 @@ var Erlang = this; // namespace
 var zlib = require('zlib');
 var lib = require('./lib');
 
+Erlang.undefinedAtom = 'undefined';
+
 // tag values here http://www.erlang.org/doc/apps/erts/erl_ext_dist.html
 var TAG_VERSION = 131;
 var TAG_COMPRESSED_ZLIB = 80;
@@ -892,7 +894,7 @@ Erlang._term_to_binary = function _term_to_binary (term) {
                     throw new OutputException('unknown javascript object type');
             }
         case 'undefined':
-            return (new Erlang.OtpErlangAtom('nil')).binary();
+            return (new Erlang.OtpErlangAtom(Erlang.undefinedAtom)).binary();
         default:
             throw new OutputException('unknown javascript type');
     }


### PR DESCRIPTION
Return undefined values as `nil` atom instead of crashing entire serialization call like this:
```
OutputException: unknown javascript type
    at new OutputException (d:\Projects\Research\Relay\_build\dev\lib\relay\priv\node\node_modules\@beenotung\erlang_js\Erlang.js:101:17)
    at Object._term_to_binary (d:\Projects\Research\Relay\_build\dev\lib\relay\priv\node\node_modules\@beenotung\erlang_js\Erlang.js:895:19)
    at Object._object_to_binary (d:\Projects\Research\Relay\_build\dev\lib\relay\priv\node\node_modules\@beenotung\erlang_js\Erlang.js:960:33)
    at Object._term_to_binary (d:\Projects\Research\Relay\_build\dev\lib\relay\priv\node\node_modules\@beenotung\erlang_js\Erlang.js:885:39)
    at Object._object_to_binary (d:\Projects\Research\Relay\_build\dev\lib\relay\priv\node\node_modules\@beenotung\erlang_js\Erlang.js:960:33)
    at Object._term_to_binary (d:\Projects\Research\Relay\_build\dev\lib\relay\priv\node\node_modules\@beenotung\erlang_js\Erlang.js:885:39)
    at Object.term_to_binary (d:\Projects\Research\Relay\_build\dev\lib\relay\priv\node\node_modules\@beenotung\erlang_js\Erlang.js:481:40)
```